### PR TITLE
Refactor server communication to JSON-RPC

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "prepare": "yarn -s tsref && yarn -s tsbuild && yarn -s download:plugins && yarn -s prepare:examples",
+    "prepare": "yarn -s clean && yarn -s tsref && yarn -s tsbuild && yarn -s download:plugins && yarn -s prepare:examples",
     "tsref": "node scripts/typescript-references.js",
     "tsbuild": "tsc -b",
     "tswatch": "tsc -b -w",

--- a/packages/base/src/experiment-manager.ts
+++ b/packages/base/src/experiment-manager.ts
@@ -6,13 +6,14 @@ import { Experiment } from 'tsp-typescript-client/lib/models/experiment';
 import { TraceManager } from './trace-manager';
 import { TspClientResponse } from 'tsp-typescript-client/lib/protocol/tsp-client-response';
 import { signalManager, Signals } from './signals/signal-manager';
+import { TspFrontendClient } from './tsp-frontend-client';
 
 export class ExperimentManager {
     private fOpenExperiments: Map<string, Experiment> = new Map();
-    private fTspClient: TspClient;
+    private fTspClient: TspClient | TspFrontendClient;
     private fTraceManager: TraceManager;
 
-    constructor(tspClient: TspClient, traceManager: TraceManager) {
+    constructor(tspClient: TspClient | TspFrontendClient, traceManager: TraceManager) {
         this.fTspClient = tspClient;
         this.fTraceManager = traceManager;
         signalManager().on(Signals.EXPERIMENT_DELETED, (experiment: Experiment) =>
@@ -79,7 +80,10 @@ export class ExperimentManager {
             traceURIs.push(traces[i].UUID);
         }
 
-        const tryCreate = async function (tspClient: TspClient, retry: number): Promise<TspClientResponse<Experiment>> {
+        const tryCreate = async function (
+            tspClient: TspClient | TspFrontendClient,
+            retry: number
+        ): Promise<TspClientResponse<Experiment>> {
             return tspClient.createExperiment(
                 new Query({
                     name: retry === 0 ? name : name + '(' + retry + ')',

--- a/packages/base/src/tsp-client-provider.ts
+++ b/packages/base/src/tsp-client-provider.ts
@@ -1,9 +1,10 @@
 import { TspClient } from 'tsp-typescript-client/lib/protocol/tsp-client';
 import { ExperimentManager } from './experiment-manager';
 import { TraceManager } from './trace-manager';
+import { TspFrontendClient } from './tsp-frontend-client';
 
 export interface ITspClientProvider {
-    getTspClient(): TspClient;
+    getTspClient(): TspClient | TspFrontendClient;
     getTraceManager(): TraceManager;
     getExperimentManager(): ExperimentManager;
     /**
@@ -11,5 +12,5 @@ export interface ITspClientProvider {
      * @param listener The listener function to be called when the url is
      * changed
      */
-    addTspClientChangeListener(listener: (tspClient: TspClient) => void): void;
+    addTspClientChangeListener(listener: (tspClient: TspClient | TspFrontendClient) => void): void;
 }

--- a/packages/base/src/tsp-frontend-client.ts
+++ b/packages/base/src/tsp-frontend-client.ts
@@ -1,0 +1,270 @@
+import { TspClientResponse } from 'tsp-typescript-client/lib/protocol/tsp-client-response';
+import { Trace } from 'tsp-typescript-client/lib/models/trace';
+import { Query } from 'tsp-typescript-client/lib/models/query/query';
+import { Experiment } from 'tsp-typescript-client/lib/models/experiment';
+import { GenericResponse } from 'tsp-typescript-client/lib/models/response/responses';
+import { HealthStatus } from 'tsp-typescript-client/lib/models/health';
+import { XyEntry, XYModel } from 'tsp-typescript-client/lib/models/xy';
+import { TimeGraphEntry, TimeGraphArrow, TimeGraphModel } from 'tsp-typescript-client/lib/models/timegraph';
+import { AnnotationCategoriesModel, AnnotationModel } from 'tsp-typescript-client/lib/models/annotation';
+import { TableModel, ColumnHeaderEntry } from 'tsp-typescript-client/lib/models/table';
+import { OutputDescriptor } from 'tsp-typescript-client/lib/models/output-descriptor';
+import { EntryModel } from 'tsp-typescript-client/lib/models/entry';
+import { OutputStyleModel } from 'tsp-typescript-client/lib/models/styles';
+import { MarkerSet } from 'tsp-typescript-client/lib/models/markerset';
+import { DataTreeEntry } from 'tsp-typescript-client/lib/models/data-tree';
+
+export const TspFrontendClient = Symbol('TspFrontendClient');
+
+export interface TspFrontendClient {
+    /**
+     * Fetch all available traces on the server
+     * @returns List of Trace
+     */
+    fetchTraces(): Promise<TspClientResponse<Trace[]>>;
+
+    /**
+     * Fetch a specific trace information
+     * @param traceUUID Trace UUID to fetch
+     */
+    fetchTrace(traceUUID: string): Promise<TspClientResponse<Trace>>;
+
+    /**
+     * Open a trace on the server
+     * @param parameters Query object
+     * @returns The opened trace
+     */
+    openTrace(parameters: Query): Promise<TspClientResponse<Trace>>;
+
+    /**
+     * Delete a trace on the server
+     * @param traceUUID Trace UUID to delete
+     * @param deleteTrace Also delete the trace from disk
+     * @param removeCache Remove all cache for this trace
+     * @returns The deleted trace
+     */
+    deleteTrace(traceUUID: string, deleteTrace?: boolean, removeCache?: boolean): Promise<TspClientResponse<Trace>>;
+
+    /**
+     * Fetch all available experiments on the server
+     * @returns List of Experiment
+     */
+    fetchExperiments(): Promise<TspClientResponse<Experiment[]>>;
+
+    /**
+     * Fetch a specific experiment information
+     * @param expUUID Experiment UUID to fetch
+     * @returns The experiment
+     */
+    fetchExperiment(expUUID: string): Promise<TspClientResponse<Experiment>>;
+
+    /**
+     * Create an experiment on the server
+     * @param parameters Query object
+     * @returns The created experiment
+     */
+    createExperiment(parameters: Query): Promise<TspClientResponse<Experiment>>;
+
+    /**
+     * Update an experiment
+     * @param expUUID Experiment UUID to update
+     * @param parameters Query object
+     * @returns The updated experiment
+     */
+    updateExperiment(expUUID: string, parameters: Query): Promise<TspClientResponse<Experiment>>;
+
+    /**
+     * Delete an experiment on the server
+     * @param expUUID Experiment UUID to delete
+     * @returns The deleted experiment
+     */
+    deleteExperiment(expUUID: string): Promise<TspClientResponse<Experiment>>;
+
+    /**
+     * List all the outputs associated to this experiment
+     * @param expUUID Experiment UUID
+     * @returns List of OutputDescriptor
+     */
+    experimentOutputs(expUUID: string): Promise<TspClientResponse<OutputDescriptor[]>>;
+
+    /**
+     * Fetch Data tree
+     * @param expUUID Experiment UUID
+     * @param outputID Output ID
+     * @param parameters Query object
+     * @returns Generic entry response with entries
+     */
+    fetchDataTree(
+        expUUID: string,
+        outputID: string,
+        parameters: Query
+    ): Promise<TspClientResponse<GenericResponse<EntryModel<DataTreeEntry>>>>;
+
+    /**
+     * Fetch XY tree
+     * @param expUUID Experiment UUID
+     * @param outputID Output ID
+     * @param parameters Query object
+     * @returns Generic entry response with entries
+     */
+    fetchXYTree(
+        expUUID: string,
+        outputID: string,
+        parameters: Query
+    ): Promise<TspClientResponse<GenericResponse<EntryModel<XyEntry>>>>;
+
+    /**
+     * Fetch XY. model extends XYModel
+     * @param expUUID Experiment UUID
+     * @param outputID Output ID
+     * @param parameters Query object
+     * @returns XY model response with the model
+     */
+    fetchXY(expUUID: string, outputID: string, parameters: Query): Promise<TspClientResponse<GenericResponse<XYModel>>>;
+
+    /**
+     * Fetch XY tooltip
+     * @param expUUID Experiment UUID
+     * @param outputID Output ID
+     * @param xValue X value
+     * @param yValue Optional Y value
+     * @param seriesID Optional series ID
+     * @returns Map of key=name of the property and value=string value associated
+     */
+    fetchXYToolTip(
+        expUUID: string,
+        outputID: string,
+        xValue: number,
+        yValue?: number,
+        seriesID?: string
+    ): Promise<TspClientResponse<GenericResponse<{ [key: string]: string }>>>;
+
+    /**
+     * Fetch Time Graph tree, Model extends TimeGraphEntry
+     * @param expUUID Experiment UUID
+     * @param outputID Output ID
+     * @param parameters Query object
+     * @returns Time graph entry response with entries of type TimeGraphEntry
+     */
+    fetchTimeGraphTree(
+        expUUID: string,
+        outputID: string,
+        parameters: Query
+    ): Promise<TspClientResponse<GenericResponse<EntryModel<TimeGraphEntry>>>>;
+
+    /**
+     * Fetch Time Graph states. Model extends TimeGraphModel
+     * @param expUUID Experiment UUID
+     * @param outputID Output ID
+     * @param parameters Query object
+     * @returns Generic response with the model
+     */
+    fetchTimeGraphStates(
+        expUUID: string,
+        outputID: string,
+        parameters: Query
+    ): Promise<TspClientResponse<GenericResponse<TimeGraphModel>>>;
+
+    /**
+     * Fetch Time Graph arrows. Model extends TimeGraphArrow
+     * @param expUUID Experiment UUID
+     * @param outputID Output ID
+     * @param parameters Query object
+     * @returns Generic response with the model
+     */
+    fetchTimeGraphArrows(
+        expUUID: string,
+        outputID: string,
+        parameters: Query
+    ): Promise<TspClientResponse<GenericResponse<TimeGraphArrow[]>>>;
+
+    /**
+     * Fetch marker sets.
+     * @returns Generic response with the model
+     */
+    fetchMarkerSets(expUUID: string): Promise<TspClientResponse<GenericResponse<MarkerSet[]>>>;
+
+    /**
+     * Fetch annotations categories.
+     * @param expUUID Experiment UUID
+     * @param outputID Output ID
+     * @param markerSetId Marker Set ID
+     * @returns Generic response with the model
+     */
+    fetchAnnotationsCategories(
+        expUUID: string,
+        outputID: string,
+        markerSetId?: string
+    ): Promise<TspClientResponse<GenericResponse<AnnotationCategoriesModel>>>;
+
+    /**
+     * Fetch annotations.
+     * @param expUUID Experiment UUID
+     * @param outputID Output ID
+     * @param parameters Query object
+     * @returns Generic response with the model
+     */
+    fetchAnnotations(
+        expUUID: string,
+        outputID: string,
+        parameters: Query
+    ): Promise<TspClientResponse<GenericResponse<AnnotationModel>>>;
+
+    /**
+     * Fetch tooltip for a Time Graph element.
+     * @param expUUID Experiment UUID
+     * @param outputID Output ID
+     * @param parameters Query object
+     * @returns Map of key=name of the property and value=string value associated
+     */
+    fetchTimeGraphTooltip(
+        expUUID: string,
+        outputID: string,
+        parameters: Query
+    ): Promise<TspClientResponse<GenericResponse<{ [key: string]: string }>>>;
+
+    /**
+     * Fetch Table columns
+     * @param expUUID Experiment UUID
+     * @param outputID Output ID
+     * @param parameters Query object
+     * @returns Generic entry response with columns headers as model
+     */
+    fetchTableColumns(
+        expUUID: string,
+        outputID: string,
+        parameters: Query
+    ): Promise<TspClientResponse<GenericResponse<ColumnHeaderEntry[]>>>;
+
+    /**
+     * Fetch Table lines
+     * @param expUUID Experiment UUID
+     * @param outputID Output ID
+     * @param parameters Query object
+     * @returns Generic response with the model
+     */
+    fetchTableLines(
+        expUUID: string,
+        outputID: string,
+        parameters: Query
+    ): Promise<TspClientResponse<GenericResponse<TableModel>>>;
+
+    /**
+     * Fetch output styles
+     * @param expUUID Experiment UUID
+     * @param outputID Output ID
+     * @param parameters Query object
+     * @returns Generic response with the model
+     */
+    fetchStyles(
+        expUUID: string,
+        outputID: string,
+        parameters: Query
+    ): Promise<TspClientResponse<GenericResponse<OutputStyleModel>>>;
+
+    /**
+     * Check the health status of the server
+     * @returns The Health Status
+     */
+    checkHealth(): Promise<TspClientResponse<HealthStatus>>;
+}

--- a/packages/react-components/src/components/abstract-output-component.tsx
+++ b/packages/react-components/src/components/abstract-output-component.tsx
@@ -11,16 +11,11 @@ import { TooltipComponent } from './tooltip-component';
 import { TooltipXYComponent } from './tooltip-xy-component';
 import { ResponseStatus } from 'tsp-typescript-client/lib/models/response/responses';
 import { signalManager } from 'traceviewer-base/lib/signals/signal-manager';
-import {
-    DropDownComponent,
-    DropDownSubSection,
-    OptionCheckBoxState,
-    OptionState,
-    OptionType
-} from './drop-down-component';
+import { DropDownComponent, DropDownSubSection, OptionState } from './drop-down-component';
+import { TspFrontendClient } from 'traceviewer-base/lib/tsp-frontend-client';
 
 export interface AbstractOutputProps {
-    tspClient: TspClient;
+    tspClient: TspClient | TspFrontendClient;
     tooltipComponent: TooltipComponent | null;
     tooltipXYComponent: TooltipXYComponent | null;
     traceId: string;

--- a/packages/react-components/src/components/abstract-xy-output-component.tsx
+++ b/packages/react-components/src/components/abstract-xy-output-component.tsx
@@ -13,7 +13,7 @@ import { EntryTree } from './utils/filter-tree/entry-tree';
 import { XyEntry, XYSeries } from 'tsp-typescript-client/lib/models/xy';
 import * as React from 'react';
 import { flushSync } from 'react-dom';
-import { TimeRange } from 'traceviewer-base/src/utils/time-range';
+import { TimeRange } from 'traceviewer-base/lib/utils/time-range';
 import { BIMath } from 'timeline-chart/lib/bigint-utils';
 import {
     XYChartFactoryParams,

--- a/packages/react-components/src/components/data-providers/style-provider.ts
+++ b/packages/react-components/src/components/data-providers/style-provider.ts
@@ -3,9 +3,10 @@ import { TspClient } from 'tsp-typescript-client/lib/protocol/tsp-client';
 import { QueryHelper } from 'tsp-typescript-client/lib/models/query/query-helper';
 import { OutputStyleModel, OutputElementStyle } from 'tsp-typescript-client/lib/models/styles';
 import { StyleProperties } from './style-properties';
+import { TspFrontendClient } from 'traceviewer-base/lib/tsp-frontend-client';
 
 export class StyleProvider {
-    private tspClient: TspClient;
+    private tspClient: TspClient | TspFrontendClient;
     private traceId: string;
     private outputId: string;
 
@@ -13,7 +14,7 @@ export class StyleProvider {
 
     private styleModel: OutputStyleModel | undefined;
 
-    constructor(outputId: string, traceId: string, tspClient: TspClient) {
+    constructor(outputId: string, traceId: string, tspClient: TspClient | TspFrontendClient) {
         this.outputId = outputId;
         this.tspClient = tspClient;
         this.traceId = traceId;

--- a/packages/react-components/src/components/data-providers/tsp-data-provider.ts
+++ b/packages/react-components/src/components/data-providers/tsp-data-provider.ts
@@ -14,6 +14,7 @@ import { OutputElementStyle } from 'tsp-typescript-client/lib/models/styles';
 import { Annotation, Type } from 'tsp-typescript-client/lib/models/annotation';
 import { TimeRange } from 'traceviewer-base/lib/utils/time-range';
 import { GenericResponse, TspClientResponse } from 'tsp-typescript-client';
+import { TspFrontendClient } from 'traceviewer-base/lib/tsp-frontend-client';
 
 enum ElementType {
     STATE = 'state',
@@ -21,7 +22,7 @@ enum ElementType {
 }
 
 export class TspDataProvider {
-    private client: TspClient;
+    private client: TspClient | TspFrontendClient;
     private outputId: string;
     private traceUUID: string;
     private timeGraphEntries: TimeGraphEntry[];
@@ -29,7 +30,7 @@ export class TspDataProvider {
 
     public totalRange: bigint;
 
-    constructor(client: TspClient, traceUUID: string, outputId: string) {
+    constructor(client: TspClient | TspFrontendClient, traceUUID: string, outputId: string) {
         this.timeGraphEntries = [];
         this.timeGraphRows = [];
         this.client = client;

--- a/packages/react-components/src/components/trace-context-component.tsx
+++ b/packages/react-components/src/components/trace-context-component.tsx
@@ -30,11 +30,12 @@ import { cloneDeep } from 'lodash';
 import { UnitControllerHistoryHandler } from './utils/unit-controller-history-handler';
 import { TraceOverviewComponent } from './trace-overview-component';
 import { TimeRangeUpdatePayload } from 'traceviewer-base/lib/signals/time-range-data-signal-payloads';
+import { TspFrontendClient } from 'traceviewer-base/lib/tsp-frontend-client';
 
 const ResponsiveGridLayout = WidthProvider(Responsive);
 
 export interface TraceContextProps {
-    tspClient: TspClient;
+    tspClient: TspClient | TspFrontendClient;
     experiment: Experiment;
     outputs: OutputDescriptor[];
     overviewDescriptor?: OutputDescriptor; // The default output descriptor for the overview

--- a/packages/react-components/src/components/trace-overview-selection-dialog-component.tsx
+++ b/packages/react-components/src/components/trace-overview-selection-dialog-component.tsx
@@ -3,9 +3,10 @@ import { OutputDescriptor, TspClient } from 'tsp-typescript-client';
 import { AbstractDialogComponent, DialogComponentProps } from './abstract-dialog-component';
 import { signalManager } from 'traceviewer-base/lib/signals/signal-manager';
 import { AvailableViewsComponent } from './utils/available-views-component';
+import { TspFrontendClient } from 'traceviewer-base/lib/tsp-frontend-client';
 
 export interface TraceOverviewSelectionComponentProps extends DialogComponentProps {
-    tspClient: TspClient;
+    tspClient: TspClient | TspFrontendClient;
     traceID: string;
 }
 

--- a/packages/react-components/src/components/utils/xy-output-component-utils.tsx
+++ b/packages/react-components/src/components/utils/xy-output-component-utils.tsx
@@ -1,4 +1,4 @@
-import { TimeRange } from 'traceviewer-base/src/utils/time-range';
+import { TimeRange } from 'traceviewer-base/lib/utils/time-range';
 import { AbstractOutputProps } from '../abstract-output-component';
 
 export interface XYChartFactoryParams {

--- a/packages/react-components/src/components/xy-output-component.tsx
+++ b/packages/react-components/src/components/xy-output-component.tsx
@@ -14,7 +14,7 @@ import {
     FLAG_ZOOM_OUT,
     MouseButton
 } from './abstract-xy-output-component';
-import { TimeRange } from 'traceviewer-base/src/utils/time-range';
+import { TimeRange } from 'traceviewer-base/lib/utils/time-range';
 import { validateNumArray } from './utils/filter-tree/utils';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faSpinner } from '@fortawesome/free-solid-svg-icons';

--- a/packages/react-components/src/components/xy-output-overview-component.tsx
+++ b/packages/react-components/src/components/xy-output-overview-component.tsx
@@ -2,7 +2,7 @@ import { AbstractOutputProps } from './abstract-output-component';
 import { ResponseStatus } from 'tsp-typescript-client/lib/models/response/responses';
 import * as React from 'react';
 import { drawSelection } from './utils/xy-output-component-utils';
-import { TimeRange } from 'traceviewer-base/src/utils/time-range';
+import { TimeRange } from 'traceviewer-base/lib/utils/time-range';
 import { AbstractXYOutputState, MouseButton } from './abstract-xy-output-component';
 import {
     AbstractXYOutputComponent,

--- a/theia-extensions/viewer-prototype/src/browser/preferences-frontend-contribution.ts
+++ b/theia-extensions/viewer-prototype/src/browser/preferences-frontend-contribution.ts
@@ -1,0 +1,23 @@
+import { FrontendApplicationContribution } from '@theia/core/lib/browser';
+import { inject, injectable } from 'inversify';
+import { PortPreferenceProxy } from '../common/trace-server-url-provider';
+import { TracePreferences, TRACE_PORT } from './trace-server-preference';
+
+@injectable()
+export class PreferencesFrontendContribution implements FrontendApplicationContribution {
+    constructor(
+        @inject(TracePreferences) protected tracePreferences: TracePreferences,
+        @inject(PortPreferenceProxy) protected portPreferenceProxy: PortPreferenceProxy
+    ) {}
+
+    async initialize(): Promise<void> {
+        this.tracePreferences.ready.then(() => {
+            this.portPreferenceProxy.onPortPreferenceChanged(this.tracePreferences[TRACE_PORT]);
+            this.tracePreferences.onPreferenceChanged(async event => {
+                const newValue = typeof event.newValue === 'string' ? parseInt(event.newValue) : event.newValue;
+                const oldValue = typeof event.oldValue === 'string' ? parseInt(event.oldValue) : event.oldValue;
+                this.portPreferenceProxy.onPortPreferenceChanged(newValue, oldValue, true);
+            });
+        });
+    }
+}

--- a/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-widget.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-widget.tsx
@@ -8,7 +8,7 @@ import { TraceExplorerServerStatusWidget } from './trace-explorer-sub-widgets/tr
 import { TraceExplorerTimeRangeDataWidget } from './trace-explorer-sub-widgets/theia-trace-explorer-time-range-data-widget';
 import { signalManager, Signals } from 'traceviewer-base/lib/signals/signal-manager';
 import { OpenedTracesUpdatedSignalPayload } from 'traceviewer-base/lib/signals/opened-traces-updated-signal-payload';
-import { TraceServerConnectionStatusService } from '../trace-server-status';
+import { TraceServerConnectionStatusClient } from '../../common/trace-server-connection-status';
 
 @injectable()
 export class TraceExplorerWidget extends BaseWidget {
@@ -24,8 +24,8 @@ export class TraceExplorerWidget extends BaseWidget {
     @inject(TraceExplorerServerStatusWidget) protected readonly serverStatusWidget!: TraceExplorerServerStatusWidget;
     @inject(TraceExplorerTimeRangeDataWidget) protected readonly timeRangeDataWidget!: TraceExplorerTimeRangeDataWidget;
     @inject(ViewContainer.Factory) protected readonly viewContainerFactory!: ViewContainer.Factory;
-    @inject(TraceServerConnectionStatusService)
-    protected readonly connectionStatusService: TraceServerConnectionStatusService;
+    @inject(TraceServerConnectionStatusClient)
+    protected readonly connectionStatusClient: TraceServerConnectionStatusClient;
 
     openExperiment(traceUUID: string): void {
         return this.openedTracesWidget.openExperiment(traceUUID);
@@ -109,10 +109,10 @@ export class TraceExplorerWidget extends BaseWidget {
     }
 
     protected onAfterShow(): void {
-        this.connectionStatusService.addConnectionStatusListener();
+        this.connectionStatusClient.addConnectionStatusListener();
     }
 
     protected onAfterHide(): void {
-        this.connectionStatusService.removeConnectionStatusListener();
+        this.connectionStatusClient.removeConnectionStatusListener();
     }
 }

--- a/theia-extensions/viewer-prototype/src/browser/trace-server-connection-status-client-impl.ts
+++ b/theia-extensions/viewer-prototype/src/browser/trace-server-connection-status-client-impl.ts
@@ -1,23 +1,28 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { injectable } from 'inversify';
-import { RestClient, ConnectionStatusListener } from 'tsp-typescript-client/lib/protocol/rest-client';
+import {
+    TraceServerConnectionStatusBackend,
+    TraceServerConnectionStatusClient
+} from '../common/trace-server-connection-status';
+import { inject } from '@theia/core/shared/inversify';
 
 @injectable()
-export class TraceServerConnectionStatusService {
-    private connectionStatusListener: ConnectionStatusListener;
+export class TraceServerConnectionStatusClientImpl implements TraceServerConnectionStatusClient {
+    constructor(
+        @inject(TraceServerConnectionStatusBackend)
+        protected traceServerConnectionStatusProxy: TraceServerConnectionStatusBackend
+    ) {}
 
-    private constructor() {
-        this.connectionStatusListener = (status: boolean) => {
-            TraceServerConnectionStatusService.renderStatus(status);
-        };
+    updateStatus(status: boolean): void {
+        TraceServerConnectionStatusClientImpl.renderStatus(status);
     }
 
     public addConnectionStatusListener(): void {
-        RestClient.addConnectionStatusListener(this.connectionStatusListener);
+        this.traceServerConnectionStatusProxy.setClient(this);
     }
 
     public removeConnectionStatusListener(): void {
-        RestClient.removeConnectionStatusListener(this.connectionStatusListener);
+        this.traceServerConnectionStatusProxy.removeClient(this);
     }
 
     static renderStatus(status: boolean): void {

--- a/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-contribution.ts
+++ b/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-contribution.ts
@@ -21,12 +21,12 @@ import {
 } from './trace-viewer-commands';
 import { PortBusy, TraceServerConfigService } from '../../common/trace-server-config';
 import { TracePreferences, TRACE_PATH, TRACE_ARGS } from '../trace-server-preference';
-import { TspClient } from 'tsp-typescript-client/lib/protocol/tsp-client';
 import { TspClientProvider } from '../tsp-client-provider-impl';
 import { ChartShortcutsDialog } from '../trace-explorer/trace-explorer-sub-widgets/charts-cheatsheet-component';
 import { signalManager } from 'traceviewer-base/lib/signals/signal-manager';
-import { TraceServerConnectionStatusService } from '../trace-server-status';
+import { TraceServerConnectionStatusClientImpl } from '../trace-server-connection-status-client-impl';
 import { FileStat } from '@theia/filesystem/lib/common/files';
+import { TspFrontendClient } from 'traceviewer-base/lib/tsp-frontend-client';
 
 interface TraceViewerWidgetOpenerOptions extends WidgetOpenerOptions {
     traceUUID: string;
@@ -37,7 +37,7 @@ export class TraceViewerContribution
     extends WidgetOpenHandler<TraceViewerWidget>
     implements CommandContribution, KeybindingContribution
 {
-    private tspClient: TspClient;
+    private tspClient: TspFrontendClient;
 
     private constructor(@inject(TspClientProvider) private tspClientProvider: TspClientProvider) {
         super();
@@ -226,7 +226,7 @@ export class TraceViewerContribution
                         } else {
                             progress.report({ message: 'Trace server started.', work: { done: 100, total: 100 } });
                         }
-                        TraceServerConnectionStatusService.renderStatus(true);
+                        TraceServerConnectionStatusClientImpl.renderStatus(true);
                         signalManager().fireTraceServerStartedSignal();
                         return;
                     }
@@ -257,7 +257,7 @@ export class TraceViewerContribution
                 try {
                     await this.traceServerConfigService.stopTraceServer();
                     this.messageService.info('Trace server terminated successfully.');
-                    TraceServerConnectionStatusService.renderStatus(false);
+                    TraceServerConnectionStatusClientImpl.renderStatus(false);
                 } catch (err) {
                     this.messageService.error('Failed to stop the trace server.');
                 }

--- a/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-frontend-module.ts
+++ b/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-frontend-module.ts
@@ -9,7 +9,6 @@ import {
 } from '@theia/core/lib/browser';
 import { TraceViewerWidget, TraceViewerWidgetOptions } from './trace-viewer';
 import { TraceViewerContribution } from './trace-viewer-contribution';
-import { TraceServerUrlProvider } from '../../common/trace-server-url-provider';
 import { CommandContribution } from '@theia/core/lib/common';
 import 'ag-grid-community/dist/styles/ag-grid.css';
 import 'ag-grid-community/dist/styles/ag-theme-balham-dark.css';
@@ -20,21 +19,27 @@ import { TraceExplorerContribution } from '../trace-explorer/trace-explorer-cont
 import { TraceExplorerWidget } from '../trace-explorer/trace-explorer-widget';
 import { TspClientProvider } from '../tsp-client-provider-impl';
 import { TheiaMessageManager } from '../theia-message-manager';
-import { TraceServerUrlProviderImpl } from '../trace-server-url-provider-frontend-impl';
 import { bindTraceServerPreferences } from '../trace-server-bindings';
-import { TraceServerConfigService, traceServerPath } from '../../common/trace-server-config';
+import { TRACE_SERVER_CLIENT, TraceServerConfigService, traceServerPath } from '../../common/trace-server-config';
 import { TabBarToolbarContribution } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
 import { TraceViewerToolbarContribution } from './trace-viewer-toolbar-contribution';
-import { LazyTspClientFactory } from 'traceviewer-base/lib/lazy-tsp-client';
 import { BackendFileService, backendFileServicePath } from '../../common/backend-file-service';
-import { TraceServerConnectionStatusService } from '../trace-server-status';
+import { TraceServerConnectionStatusClientImpl } from '../trace-server-connection-status-client-impl';
 import { bindTraceOverviewPreferences } from '../trace-overview-binding';
+import { TspFrontendClient } from 'traceviewer-base/lib/tsp-frontend-client';
+import { TspClient } from 'tsp-typescript-client/lib/protocol/tsp-client';
+import { PortPreferenceProxy, TRACE_SERVER_PORT } from '../../common/trace-server-url-provider';
+import { PreferencesFrontendContribution } from '../preferences-frontend-contribution';
+import {
+    TRACE_SERVER_CONNECTION_STATUS,
+    TraceServerConnectionStatusBackend,
+    TraceServerConnectionStatusClient
+} from '../../common/trace-server-connection-status';
+import { TspFrontendClientImpl } from '../tsp-frontend-client-impl';
 
 export default new ContainerModule(bind => {
-    bind(TraceServerUrlProviderImpl).toSelf().inSingletonScope();
-    bind(FrontendApplicationContribution).toService(TraceServerUrlProviderImpl);
-    bind(TraceServerUrlProvider).toService(TraceServerUrlProviderImpl);
-    bind(LazyTspClientFactory).toFunction(LazyTspClientFactory);
+    bind(PreferencesFrontendContribution).toSelf().inSingletonScope();
+    bind(FrontendApplicationContribution).toService(PreferencesFrontendContribution);
     bind(TspClientProvider).toSelf().inSingletonScope();
     bind(TheiaMessageManager).toSelf().inSingletonScope();
 
@@ -42,8 +47,8 @@ export default new ContainerModule(bind => {
     bind(FrontendApplicationContribution).toService(TraceViewerToolbarContribution);
     bind(TabBarToolbarContribution).toService(TraceViewerToolbarContribution);
     bind(CommandContribution).toService(TraceViewerToolbarContribution);
-    bind(TraceServerConnectionStatusService).toSelf().inSingletonScope();
-    bind(FrontendApplicationContribution).toService(TraceServerConnectionStatusService);
+    bind(TraceServerConnectionStatusClient).to(TraceServerConnectionStatusClientImpl).inSingletonScope();
+    bind(FrontendApplicationContribution).toService(TraceServerConnectionStatusClient);
 
     bind(TraceViewerWidget).toSelf();
     bind<WidgetFactory>(WidgetFactory)
@@ -88,4 +93,27 @@ export default new ContainerModule(bind => {
             return connection.createProxy<BackendFileService>(backendFileServicePath);
         })
         .inSingletonScope();
+
+    bind(TspClient)
+        .toDynamicValue(ctx => {
+            const connection = ctx.container.get(WebSocketConnectionProvider);
+            return connection.createProxy<TspClient>(TRACE_SERVER_CLIENT);
+        })
+        .inSingletonScope();
+
+    bind(PortPreferenceProxy)
+        .toDynamicValue(ctx => {
+            const connection = ctx.container.get(WebSocketConnectionProvider);
+            return connection.createProxy<PortPreferenceProxy>(TRACE_SERVER_PORT);
+        })
+        .inSingletonScope();
+
+    bind(TraceServerConnectionStatusBackend)
+        .toDynamicValue(ctx => {
+            const connection = ctx.container.get(WebSocketConnectionProvider);
+            return connection.createProxy<TraceServerConnectionStatusBackend>(TRACE_SERVER_CONNECTION_STATUS);
+        })
+        .inSingletonScope();
+
+    bind(TspFrontendClient).to(TspFrontendClientImpl).inSingletonScope();
 });

--- a/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer.tsx
@@ -4,7 +4,6 @@ import { ReactWidget } from '@theia/core/lib/browser/widgets/react-widget';
 import { inject, injectable, postConstruct } from 'inversify';
 import { OutputDescriptor } from 'tsp-typescript-client/lib/models/output-descriptor';
 import { Trace } from 'tsp-typescript-client/lib/models/trace';
-import { TspClient } from 'tsp-typescript-client/lib/protocol/tsp-client';
 import { TspClientProvider } from '../tsp-client-provider-impl';
 import { TraceManager } from 'traceviewer-base/lib/trace-manager';
 import { ExperimentManager } from 'traceviewer-base/lib/experiment-manager';
@@ -34,6 +33,7 @@ import {
     getSwitchToDefaultViewErrorMessage,
     OverviewPreferences
 } from '../trace-overview-preference';
+import { TspFrontendClient } from 'traceviewer-base/lib/tsp-frontend-client';
 
 export const TraceViewerWidgetOptions = Symbol('TraceViewerWidgetOptions');
 export interface TraceViewerWidgetOptions {
@@ -49,7 +49,7 @@ export class TraceViewerWidget extends ReactWidget implements StatefulWidget {
     protected uri: Path;
     protected openedExperiment: Experiment | undefined;
     protected outputDescriptors: OutputDescriptor[] = [];
-    protected tspClient: TspClient;
+    protected tspClient: TspFrontendClient;
     protected traceManager: TraceManager;
     protected experimentManager: ExperimentManager;
     protected backgroundTheme: string;

--- a/theia-extensions/viewer-prototype/src/browser/tsp-client-provider-impl.ts
+++ b/theia-extensions/viewer-prototype/src/browser/tsp-client-provider-impl.ts
@@ -1,41 +1,24 @@
 import { injectable, inject } from 'inversify';
-import { TraceServerUrlProvider } from '../common/trace-server-url-provider';
-import { TspClient } from 'tsp-typescript-client/lib/protocol/tsp-client';
 import { ExperimentManager } from 'traceviewer-base/lib/experiment-manager';
 import { TraceManager } from 'traceviewer-base/lib/trace-manager';
 import { ITspClientProvider } from 'traceviewer-base/lib/tsp-client-provider';
-import { LazyTspClientFactory } from 'traceviewer-base/lib/lazy-tsp-client';
+import { TspFrontendClient } from 'traceviewer-base/lib/tsp-frontend-client';
 
 @injectable()
 export class TspClientProvider implements ITspClientProvider {
-    private _tspClient: TspClient;
+    private _tspClient: TspFrontendClient;
     private _traceManager: TraceManager;
     private _experimentManager: ExperimentManager;
-    private _listeners: ((tspClient: TspClient) => void)[];
+    private _listeners: ((tspClient: TspFrontendClient) => void)[];
 
-    constructor(
-        @inject(TraceServerUrlProvider) private tspUrlProvider: TraceServerUrlProvider,
-        @inject(LazyTspClientFactory) private lazyTspClientFactory: LazyTspClientFactory
-    ) {
-        const traceServerUrlPromise = this.tspUrlProvider.getTraceServerUrlPromise();
-        this._tspClient = this.lazyTspClientFactory(traceServerUrlPromise);
+    constructor(@inject(TspFrontendClient) protected client: TspFrontendClient) {
+        this._tspClient = client;
         this._traceManager = new TraceManager(this._tspClient);
         this._experimentManager = new ExperimentManager(this._tspClient, this._traceManager);
         this._listeners = [];
-        // Skip the first event fired when the Trace Server URL gets initialized.
-        traceServerUrlPromise.then(() => {
-            tspUrlProvider.onDidChangeTraceServerUrl(url => {
-                this._tspClient = new TspClient(url);
-                this._traceManager = new TraceManager(this._tspClient);
-                this._experimentManager = new ExperimentManager(this._tspClient, this._traceManager);
-                for (const listener of this._listeners) {
-                    listener(this._tspClient);
-                }
-            });
-        });
     }
 
-    public getTspClient(): TspClient {
+    public getTspClient(): TspFrontendClient {
         return this._tspClient;
     }
 
@@ -52,7 +35,7 @@ export class TspClientProvider implements ITspClientProvider {
      * @param listener The listener function to be called when the url is
      * changed
      */
-    addTspClientChangeListener(listener: (tspClient: TspClient) => void): void {
+    addTspClientChangeListener(listener: (tspClient: TspFrontendClient) => void): void {
         this._listeners.push(listener);
     }
 }

--- a/theia-extensions/viewer-prototype/src/browser/tsp-frontend-client-impl.ts
+++ b/theia-extensions/viewer-prototype/src/browser/tsp-frontend-client-impl.ts
@@ -1,0 +1,369 @@
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { TspClient } from 'tsp-typescript-client/lib/protocol/tsp-client';
+import { TspClientResponse } from 'tsp-typescript-client/lib/protocol/tsp-client-response';
+import { Trace } from 'tsp-typescript-client/lib/models/trace';
+import { Query } from 'tsp-typescript-client/lib/models/query/query';
+import { Experiment } from 'tsp-typescript-client/lib/models/experiment';
+import { GenericResponse } from 'tsp-typescript-client/lib/models/response/responses';
+import { HealthStatus } from 'tsp-typescript-client/lib/models/health';
+import { XyEntry, XYModel } from 'tsp-typescript-client/lib/models/xy';
+import { TimeGraphEntry, TimeGraphArrow, TimeGraphModel } from 'tsp-typescript-client/lib/models/timegraph';
+import { AnnotationCategoriesModel, AnnotationModel } from 'tsp-typescript-client/lib/models/annotation';
+import { TableModel, ColumnHeaderEntry } from 'tsp-typescript-client/lib/models/table';
+import { OutputDescriptor } from 'tsp-typescript-client/lib/models/output-descriptor';
+import { EntryModel } from 'tsp-typescript-client/lib/models/entry';
+import { OutputStyleModel } from 'tsp-typescript-client/lib/models/styles';
+import { MarkerSet } from 'tsp-typescript-client/lib/models/markerset';
+import { DataTreeEntry } from 'tsp-typescript-client/lib/models/data-tree';
+import { TspFrontendClient } from 'traceviewer-base/lib/tsp-frontend-client';
+
+@injectable()
+export class TspFrontendClientImpl implements TspFrontendClient {
+    public constructor(@inject(TspClient) protected tspClient: TspClient) {}
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
+    protected toTspClientResponse<T>(result: any): TspClientResponse<T> {
+        const tspClientResponse: TspClientResponse<T> = new TspClientResponse(
+            result.text,
+            result.statusCode,
+            result.statusMessage,
+            result.responseModel
+        );
+        return tspClientResponse;
+    }
+
+    /**
+     * Fetch all available traces on the server
+     * @returns List of Trace
+     */
+    public async fetchTraces(): Promise<TspClientResponse<Trace[]>> {
+        return this.toTspClientResponse<Trace[]>(await this.tspClient.fetchTraces());
+    }
+
+    /**
+     * Fetch a specific trace information
+     * @param traceUUID Trace UUID to fetch
+     */
+    public async fetchTrace(traceUUID: string): Promise<TspClientResponse<Trace>> {
+        return this.toTspClientResponse<Trace>(await this.tspClient.fetchTrace(traceUUID));
+    }
+
+    /**
+     * Open a trace on the server
+     * @param parameters Query object
+     * @returns The opened trace
+     */
+    public async openTrace(parameters: Query): Promise<TspClientResponse<Trace>> {
+        return this.toTspClientResponse<Trace>(await this.tspClient.openTrace(parameters));
+    }
+
+    /**
+     * Delete a trace on the server
+     * @param traceUUID Trace UUID to delete
+     * @param deleteTrace Also delete the trace from disk
+     * @param removeCache Remove all cache for this trace
+     * @returns The deleted trace
+     */
+    public async deleteTrace(
+        traceUUID: string,
+        deleteTrace?: boolean,
+        removeCache?: boolean
+    ): Promise<TspClientResponse<Trace>> {
+        return this.toTspClientResponse<Trace>(await this.tspClient.deleteTrace(traceUUID, deleteTrace, removeCache));
+    }
+
+    /**
+     * Fetch all available experiments on the server
+     * @returns List of Experiment
+     */
+    public async fetchExperiments(): Promise<TspClientResponse<Experiment[]>> {
+        return this.toTspClientResponse<Experiment[]>(await this.tspClient.fetchExperiments());
+    }
+
+    /**
+     * Fetch a specific experiment information
+     * @param expUUID Experiment UUID to fetch
+     * @returns The experiment
+     */
+    public async fetchExperiment(expUUID: string): Promise<TspClientResponse<Experiment>> {
+        return this.toTspClientResponse<Experiment>(await this.tspClient.fetchExperiment(expUUID));
+    }
+
+    /**
+     * Create an experiment on the server
+     * @param parameters Query object
+     * @returns The created experiment
+     */
+    public async createExperiment(parameters: Query): Promise<TspClientResponse<Experiment>> {
+        return this.toTspClientResponse<Experiment>(await this.tspClient.createExperiment(parameters));
+    }
+
+    /**
+     * Update an experiment
+     * @param expUUID Experiment UUID to update
+     * @param parameters Query object
+     * @returns The updated experiment
+     */
+    public async updateExperiment(expUUID: string, parameters: Query): Promise<TspClientResponse<Experiment>> {
+        return this.toTspClientResponse<Experiment>(await this.tspClient.updateExperiment(expUUID, parameters));
+    }
+
+    /**
+     * Delete an experiment on the server
+     * @param expUUID Experiment UUID to delete
+     * @returns The deleted experiment
+     */
+    public async deleteExperiment(expUUID: string): Promise<TspClientResponse<Experiment>> {
+        return this.toTspClientResponse<Experiment>(await this.tspClient.deleteExperiment(expUUID));
+    }
+
+    /**
+     * List all the outputs associated to this experiment
+     * @param expUUID Experiment UUID
+     * @returns List of OutputDescriptor
+     */
+    public async experimentOutputs(expUUID: string): Promise<TspClientResponse<OutputDescriptor[]>> {
+        return this.toTspClientResponse<OutputDescriptor[]>(await this.tspClient.experimentOutputs(expUUID));
+    }
+
+    /**
+     * Fetch Data tree
+     * @param expUUID Experiment UUID
+     * @param outputID Output ID
+     * @param parameters Query object
+     * @returns Generic entry response with entries
+     */
+    public async fetchDataTree(
+        expUUID: string,
+        outputID: string,
+        parameters: Query
+    ): Promise<TspClientResponse<GenericResponse<EntryModel<DataTreeEntry>>>> {
+        return this.toTspClientResponse<GenericResponse<EntryModel<DataTreeEntry>>>(
+            await this.tspClient.fetchDataTree(expUUID, outputID, parameters)
+        );
+    }
+
+    /**
+     * Fetch XY tree
+     * @param expUUID Experiment UUID
+     * @param outputID Output ID
+     * @param parameters Query object
+     * @returns Generic entry response with entries
+     */
+    public async fetchXYTree(
+        expUUID: string,
+        outputID: string,
+        parameters: Query
+    ): Promise<TspClientResponse<GenericResponse<EntryModel<XyEntry>>>> {
+        return this.toTspClientResponse<GenericResponse<EntryModel<XyEntry>>>(
+            await this.tspClient.fetchXYTree(expUUID, outputID, parameters)
+        );
+    }
+
+    /**
+     * Fetch XY. model extends XYModel
+     * @param expUUID Experiment UUID
+     * @param outputID Output ID
+     * @param parameters Query object
+     * @returns XY model response with the model
+     */
+    public async fetchXY(
+        expUUID: string,
+        outputID: string,
+        parameters: Query
+    ): Promise<TspClientResponse<GenericResponse<XYModel>>> {
+        return this.toTspClientResponse<GenericResponse<XYModel>>(
+            await this.tspClient.fetchXY(expUUID, outputID, parameters)
+        );
+    }
+
+    /**
+     * Fetch XY tooltip
+     * @param expUUID Experiment UUID
+     * @param outputID Output ID
+     * @param xValue X value
+     * @param yValue Optional Y value
+     * @param seriesID Optional series ID
+     * @returns Map of key=name of the property and value=string value associated
+     */
+    public async fetchXYToolTip(
+        expUUID: string,
+        outputID: string,
+        xValue: number,
+        yValue?: number,
+        seriesID?: string
+    ): Promise<TspClientResponse<GenericResponse<{ [key: string]: string }>>> {
+        return this.toTspClientResponse<GenericResponse<{ [key: string]: string }>>(
+            await this.tspClient.fetchXYToolTip(expUUID, outputID, xValue, yValue, seriesID)
+        );
+    }
+
+    /**
+     * Fetch Time Graph tree, Model extends TimeGraphEntry
+     * @param expUUID Experiment UUID
+     * @param outputID Output ID
+     * @param parameters Query object
+     * @returns Time graph entry response with entries of type TimeGraphEntry
+     */
+    public async fetchTimeGraphTree(
+        expUUID: string,
+        outputID: string,
+        parameters: Query
+    ): Promise<TspClientResponse<GenericResponse<EntryModel<TimeGraphEntry>>>> {
+        return this.toTspClientResponse<GenericResponse<EntryModel<TimeGraphEntry>>>(
+            await this.tspClient.fetchTimeGraphTree(expUUID, outputID, parameters)
+        );
+    }
+
+    /**
+     * Fetch Time Graph states. Model extends TimeGraphModel
+     * @param expUUID Experiment UUID
+     * @param outputID Output ID
+     * @param parameters Query object
+     * @returns Generic response with the model
+     */
+    public async fetchTimeGraphStates(
+        expUUID: string,
+        outputID: string,
+        parameters: Query
+    ): Promise<TspClientResponse<GenericResponse<TimeGraphModel>>> {
+        return this.toTspClientResponse<GenericResponse<TimeGraphModel>>(
+            await this.tspClient.fetchTimeGraphStates(expUUID, outputID, parameters)
+        );
+    }
+
+    /**
+     * Fetch Time Graph arrows. Model extends TimeGraphArrow
+     * @param expUUID Experiment UUID
+     * @param outputID Output ID
+     * @param parameters Query object
+     * @returns Generic response with the model
+     */
+    public async fetchTimeGraphArrows(
+        expUUID: string,
+        outputID: string,
+        parameters: Query
+    ): Promise<TspClientResponse<GenericResponse<TimeGraphArrow[]>>> {
+        return this.toTspClientResponse<GenericResponse<TimeGraphArrow[]>>(
+            await this.tspClient.fetchTimeGraphArrows(expUUID, outputID, parameters)
+        );
+    }
+
+    /**
+     * Fetch marker sets.
+     * @returns Generic response with the model
+     */
+    public async fetchMarkerSets(expUUID: string): Promise<TspClientResponse<GenericResponse<MarkerSet[]>>> {
+        return this.toTspClientResponse<GenericResponse<MarkerSet[]>>(await this.tspClient.fetchMarkerSets(expUUID));
+    }
+
+    /**
+     * Fetch annotations categories.
+     * @param expUUID Experiment UUID
+     * @param outputID Output ID
+     * @param markerSetId Marker Set ID
+     * @returns Generic response with the model
+     */
+    public async fetchAnnotationsCategories(
+        expUUID: string,
+        outputID: string,
+        markerSetId?: string
+    ): Promise<TspClientResponse<GenericResponse<AnnotationCategoriesModel>>> {
+        return this.toTspClientResponse<GenericResponse<AnnotationCategoriesModel>>(
+            await this.tspClient.fetchAnnotationsCategories(expUUID, outputID, markerSetId)
+        );
+    }
+
+    /**
+     * Fetch annotations.
+     * @param expUUID Experiment UUID
+     * @param outputID Output ID
+     * @param parameters Query object
+     * @returns Generic response with the model
+     */
+    public async fetchAnnotations(
+        expUUID: string,
+        outputID: string,
+        parameters: Query
+    ): Promise<TspClientResponse<GenericResponse<AnnotationModel>>> {
+        return this.toTspClientResponse<GenericResponse<AnnotationModel>>(
+            await this.tspClient.fetchAnnotations(expUUID, outputID, parameters)
+        );
+    }
+
+    /**
+     * Fetch tooltip for a Time Graph element.
+     * @param expUUID Experiment UUID
+     * @param outputID Output ID
+     * @param parameters Query object
+     * @returns Map of key=name of the property and value=string value associated
+     */
+    public async fetchTimeGraphTooltip(
+        expUUID: string,
+        outputID: string,
+        parameters: Query
+    ): Promise<TspClientResponse<GenericResponse<{ [key: string]: string }>>> {
+        return this.toTspClientResponse<GenericResponse<{ [key: string]: string }>>(
+            await this.tspClient.fetchTimeGraphTooltip(expUUID, outputID, parameters)
+        );
+    }
+
+    /**
+     * Fetch Table columns
+     * @param expUUID Experiment UUID
+     * @param outputID Output ID
+     * @param parameters Query object
+     * @returns Generic entry response with columns headers as model
+     */
+    public async fetchTableColumns(
+        expUUID: string,
+        outputID: string,
+        parameters: Query
+    ): Promise<TspClientResponse<GenericResponse<ColumnHeaderEntry[]>>> {
+        return this.toTspClientResponse<GenericResponse<ColumnHeaderEntry[]>>(
+            await this.tspClient.fetchTableColumns(expUUID, outputID, parameters)
+        );
+    }
+
+    /**
+     * Fetch Table lines
+     * @param expUUID Experiment UUID
+     * @param outputID Output ID
+     * @param parameters Query object
+     * @returns Generic response with the model
+     */
+    public async fetchTableLines(
+        expUUID: string,
+        outputID: string,
+        parameters: Query
+    ): Promise<TspClientResponse<GenericResponse<TableModel>>> {
+        return this.toTspClientResponse<GenericResponse<TableModel>>(
+            await this.tspClient.fetchTableLines(expUUID, outputID, parameters)
+        );
+    }
+
+    /**
+     * Fetch output styles
+     * @param expUUID Experiment UUID
+     * @param outputID Output ID
+     * @param parameters Query object
+     * @returns Generic response with the model
+     */
+    public async fetchStyles(
+        expUUID: string,
+        outputID: string,
+        parameters: Query
+    ): Promise<TspClientResponse<GenericResponse<OutputStyleModel>>> {
+        return this.toTspClientResponse<GenericResponse<OutputStyleModel>>(
+            await this.tspClient.fetchStyles(expUUID, outputID, parameters)
+        );
+    }
+
+    /**
+     * Check the health status of the server
+     * @returns The Health Status
+     */
+    public async checkHealth(): Promise<TspClientResponse<HealthStatus>> {
+        return this.toTspClientResponse<HealthStatus>(await this.tspClient.checkHealth());
+    }
+}

--- a/theia-extensions/viewer-prototype/src/common/trace-server-config.ts
+++ b/theia-extensions/viewer-prototype/src/common/trace-server-config.ts
@@ -1,6 +1,8 @@
 import { ApplicationError } from '@theia/core';
 
 export const traceServerPath = '/services/theia-trace-extension/trace-server-config';
+export const TRACE_SERVER_CLIENT = '/services/theia-trace-extension/trace-server-client';
+
 export const PortBusy = ApplicationError.declare(-32650, code => ({
     message: 'Port busy',
     data: { code }

--- a/theia-extensions/viewer-prototype/src/common/trace-server-connection-status.ts
+++ b/theia-extensions/viewer-prototype/src/common/trace-server-connection-status.ts
@@ -1,0 +1,34 @@
+export const TraceServerConnectionStatusBackend = Symbol('TraceServerConnectionStatusBackend');
+
+export const TRACE_SERVER_CONNECTION_STATUS = '/services/theia-trace-extension/trace-server-connection-status';
+
+export interface TraceServerConnectionStatusBackend {
+    /**
+     * Set a new TraceServerConnectionStatusClient to be notified on status changes.
+     * @param client the client to be notified.
+     */
+    setClient(client: TraceServerConnectionStatusClient): void;
+    /**
+     * Remove a new TraceServerConnectionStatusClient so it won't no longer be notified on status changes.
+     * @param client the client to be removed.
+     */
+    removeClient(client: TraceServerConnectionStatusClient): void;
+}
+
+export const TraceServerConnectionStatusClient = Symbol('TraceServerConnectionStatusClient');
+
+export interface TraceServerConnectionStatusClient {
+    /**
+     * Update the status on the client.
+     * @param status the new value of the status.
+     */
+    updateStatus(status: boolean): void;
+    /**
+     * Subscribe this client to the connection status
+     */
+    addConnectionStatusListener(): void;
+    /**
+     * Unsubscribe this client from the connection status
+     */
+    removeConnectionStatusListener(): void;
+}

--- a/theia-extensions/viewer-prototype/src/common/trace-server-url-provider.ts
+++ b/theia-extensions/viewer-prototype/src/common/trace-server-url-provider.ts
@@ -22,3 +22,16 @@ export interface TraceServerUrlProvider {
      */
     onDidChangeTraceServerUrl(listener: (url: string) => void): void;
 }
+
+export const TRACE_SERVER_PORT = '/services/theia-trace-extension/trace-server-port';
+
+export const PortPreferenceProxy = Symbol('PortPreferenceProxy');
+export interface PortPreferenceProxy {
+    /**
+     * Notify the backend about a change of the port preference.
+     * @param newPort the new value of the port preference.
+     * @param oldValue the old value of the port preference.
+     * @param preferenceChanged boolean that indicated whether the preference was changed or initialized.
+     */
+    onPortPreferenceChanged(newPort: number | undefined, oldValue?: number, preferenceChanged?: boolean): Promise<void>;
+}

--- a/theia-extensions/viewer-prototype/src/node/trace-server-connection-status-backend-impl.ts
+++ b/theia-extensions/viewer-prototype/src/node/trace-server-connection-status-backend-impl.ts
@@ -1,0 +1,29 @@
+import { injectable } from 'inversify';
+import { RestClient } from 'tsp-typescript-client/lib/protocol/rest-client';
+import {
+    TraceServerConnectionStatusBackend,
+    TraceServerConnectionStatusClient
+} from '../common/trace-server-connection-status';
+
+@injectable()
+export class TraceServerConnectionStatusBackendImpl implements TraceServerConnectionStatusBackend {
+    protected clients: TraceServerConnectionStatusClient[] = [];
+
+    constructor() {
+        const listener = (status: boolean) => {
+            this.clients.forEach(client => client.updateStatus(status));
+        };
+        RestClient.addConnectionStatusListener(listener);
+    }
+
+    setClient(client: TraceServerConnectionStatusClient): void {
+        this.clients.push(client);
+    }
+
+    removeClient(client: TraceServerConnectionStatusClient): void {
+        const index = this.clients.indexOf(client);
+        if (index > -1) {
+            this.clients.splice(index, 1);
+        }
+    }
+}

--- a/theia-extensions/viewer-prototype/src/node/trace-server-url-provider-impl.ts
+++ b/theia-extensions/viewer-prototype/src/node/trace-server-url-provider-impl.ts
@@ -1,13 +1,17 @@
-import { Emitter, Event, MessageService } from '@theia/core';
-import { FrontendApplicationContribution } from '@theia/core/lib/browser';
-import { EnvVariablesServer } from '@theia/core/lib/common/env-variables/env-variables-protocol';
 import { inject, injectable } from 'inversify';
 import { TraceServerConfigService } from '../common/trace-server-config';
-import { TraceServerUrlProvider, TRACE_SERVER_DEFAULT_URL } from '../common/trace-server-url-provider';
-import { TracePreferences, TRACE_PORT } from './trace-server-preference';
+import {
+    TraceServerUrlProvider,
+    TRACE_SERVER_DEFAULT_URL,
+    PortPreferenceProxy
+} from '../common/trace-server-url-provider';
+import { Event, Emitter } from '@theia/core';
+import { BackendApplicationContribution } from '@theia/core/lib/node';
 
 @injectable()
-export class TraceServerUrlProviderImpl implements TraceServerUrlProvider, FrontendApplicationContribution {
+export class TraceServerUrlProviderImpl
+    implements TraceServerUrlProvider, BackendApplicationContribution, PortPreferenceProxy
+{
     /**
      * The Trace Server URL resolved from a URL template and a port number.
      * Updated each time the port is changed from the preferences.
@@ -45,12 +49,7 @@ export class TraceServerUrlProviderImpl implements TraceServerUrlProvider, Front
         return this._onDidChangeTraceServerUrlEmitter.event;
     }
 
-    constructor(
-        @inject(EnvVariablesServer) protected environment: EnvVariablesServer,
-        @inject(TracePreferences) protected tracePreferences: TracePreferences,
-        @inject(TraceServerConfigService) protected traceServerConfigService: TraceServerConfigService,
-        @inject(MessageService) protected messageService: MessageService
-    ) {
+    constructor(@inject(TraceServerConfigService) protected traceServerConfigService: TraceServerConfigService) {
         this._traceServerUrlPromise = new Promise(resolve => {
             const self = this.onDidChangeTraceServerUrl(url => {
                 self.dispose();
@@ -58,28 +57,28 @@ export class TraceServerUrlProviderImpl implements TraceServerUrlProvider, Front
             });
         });
         // Get the URL template from the remote environment.
-        this.environment.getValue('TRACE_SERVER_URL').then(variable => {
-            const url = variable?.value;
-            this._traceServerUrlTemplate = url ? this.normalizeUrl(url) : TRACE_SERVER_DEFAULT_URL;
-            this.updateTraceServerUrl();
-        });
-        // Get the configurable port from Theia's preferences.
-        this.tracePreferences.ready.then(() => {
-            this._traceServerPort = this.tracePreferences[TRACE_PORT];
-            this.updateTraceServerUrl();
-            this.tracePreferences.onPreferenceChanged(async event => {
-                if (event.preferenceName === TRACE_PORT) {
-                    this._traceServerPort = event.newValue;
-                    this.updateTraceServerUrl();
-                    try {
-                        await this.traceServerConfigService.stopTraceServer();
-                        this.messageService.info(`Trace server disconnected on port: ${event.oldValue}.`);
-                    } catch (_) {
-                        // Do not show the error incase the user tries to modify the port before starting a server
-                    }
+        const variable = process.env['TRACE_SERVER_URL'];
+        this._traceServerUrlTemplate = variable ? this.normalizeUrl(variable) : TRACE_SERVER_DEFAULT_URL;
+        this.updateTraceServerUrl();
+    }
+
+    async onPortPreferenceChanged(
+        newPort: number | undefined,
+        oldValue?: number,
+        preferenceChanged = false
+    ): Promise<void> {
+        this._traceServerPort = newPort;
+        this.updateTraceServerUrl();
+        if (preferenceChanged) {
+            try {
+                await this.traceServerConfigService.stopTraceServer();
+                if (oldValue) {
+                    console.info(`Trace server disconnected on port: ${oldValue}.`);
                 }
-            });
-        });
+            } catch (_) {
+                // Do not show the error incase the user tries to modify the port before starting a server
+            }
+        }
     }
 
     async initialize(): Promise<void> {

--- a/theia-extensions/viewer-prototype/src/node/viewer-prototype-backend-module.ts
+++ b/theia-extensions/viewer-prototype/src/node/viewer-prototype-backend-module.ts
@@ -1,12 +1,27 @@
 import { ContainerModule } from 'inversify';
 import { ConnectionHandler, JsonRpcConnectionHandler } from '@theia/core/lib/common';
-import { traceServerPath } from '../common/trace-server-config';
+import { TRACE_SERVER_CLIENT, traceServerPath } from '../common/trace-server-config';
 import { TraceServerConfigService } from '../common/trace-server-config';
 import { BackendFileService, backendFileServicePath } from '../common/backend-file-service';
 import { BackendFileServiceImpl } from './backend-file-service-impl';
+import { PortPreferenceProxy, TRACE_SERVER_PORT, TraceServerUrlProvider } from '../common/trace-server-url-provider';
+import { TraceServerUrlProviderImpl } from './trace-server-url-provider-impl';
+import { BackendApplicationContribution } from '@theia/core/lib/node';
+import { LazyTspClientFactory } from 'traceviewer-base/lib/lazy-tsp-client';
+import { TraceServerConnectionStatusBackendImpl } from './trace-server-connection-status-backend-impl';
+import {
+    TRACE_SERVER_CONNECTION_STATUS,
+    TraceServerConnectionStatusBackend
+} from '../common/trace-server-connection-status';
 
 export default new ContainerModule(bind => {
+    bind(LazyTspClientFactory).toFunction(LazyTspClientFactory);
     bind(BackendFileService).to(BackendFileServiceImpl).inSingletonScope();
+    bind(TraceServerUrlProviderImpl).toSelf().inSingletonScope();
+    bind(TraceServerUrlProvider).to(TraceServerUrlProviderImpl).inSingletonScope();
+    bind(BackendApplicationContribution).toService(TraceServerUrlProvider);
+    bind(PortPreferenceProxy).toService(TraceServerUrlProvider);
+    bind(TraceServerConnectionStatusBackend).to(TraceServerConnectionStatusBackendImpl).inSingletonScope();
     bind(ConnectionHandler)
         .toDynamicValue(
             ctx =>
@@ -20,6 +35,33 @@ export default new ContainerModule(bind => {
             ctx =>
                 new JsonRpcConnectionHandler(backendFileServicePath, () =>
                     ctx.container.get<BackendFileService>(BackendFileService)
+                )
+        )
+        .inSingletonScope();
+    bind(ConnectionHandler)
+        .toDynamicValue(
+            ctx =>
+                new JsonRpcConnectionHandler(TRACE_SERVER_CLIENT, () => {
+                    const provider = ctx.container.get<TraceServerUrlProvider>(TraceServerUrlProvider);
+                    const lazyTspClientFactory = ctx.container.get<LazyTspClientFactory>(LazyTspClientFactory);
+                    const traceServerUrlPromise = provider.getTraceServerUrlPromise();
+                    return lazyTspClientFactory(traceServerUrlPromise);
+                })
+        )
+        .inSingletonScope();
+    bind(ConnectionHandler)
+        .toDynamicValue(
+            ctx =>
+                new JsonRpcConnectionHandler(TRACE_SERVER_PORT, () =>
+                    ctx.container.get<PortPreferenceProxy>(PortPreferenceProxy)
+                )
+        )
+        .inSingletonScope();
+    bind(ConnectionHandler)
+        .toDynamicValue(
+            ctx =>
+                new JsonRpcConnectionHandler(TRACE_SERVER_CONNECTION_STATUS, () =>
+                    ctx.container.get<TraceServerConnectionStatusBackend>(TraceServerConnectionStatusBackend)
                 )
         )
         .inSingletonScope();


### PR DESCRIPTION
Base package:
- created a new TspFrontendClient interface that follows the TspClient
- each tspClient is now either a TspFrontendClient or a TspClient
- this is also true for all the react components
- this way all tspClients can be used with or without JSON-RPC
- note that this interface could be moved to tsp-typescript-client
- then the TspClient could also follow the same interface

Theia-extension:
- a implementation for the TspFrontendClient is provided
- it calls the JSON-RPC proxy on the backend and transforms the responses to TspClientResponses so they can be handled as before
- the backend proxy simply the urlPromise and returns a lazyTspClient
- the trace-server-url-provider-impl was also moved to the backend
- this way the env variable can directly be read out from process.env
- for the port preference a proxy was setup in the url-provider
- with it the url provider gets notified about port changes
- the trace-server-connection-status was also moved to the backend
- the frontend client for the connection-status registers on the backend
- the backend then pings all registered clients when the status changed

Fixes # 976

Contributed on behalf of STMicroelectronics